### PR TITLE
Clarify max byte error message.

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = (options) => {
             options.enableByteLimit &&
             ampCustom.isOverMaxByte(cssSource)
         ) {
-            this.emit('error', new PluginError(PLUGIN_NAME, 'The capacity of the CSS source is 50 KB or more.'));
+            this.emit('error', new PluginError(PLUGIN_NAME, 'AMP stylesheet exceeds the 50,000 btyes limit.'));
         }
 
         file.contents = Buffer.from(cssSource);


### PR DESCRIPTION
Hi there.

Great plugin.  This is just a small change to make the over byte message a little clearer, and bring it in line with the language used by AMP.  See: https://www.ampproject.org/docs/design/responsive_amp#validate-your-styles-and-layout